### PR TITLE
allow tests to pass on windows

### DIFF
--- a/t/funcs.pm
+++ b/t/funcs.pm
@@ -37,10 +37,11 @@ sub _ack {
     my ($fn, $text, $msg) = @_;
     $text ||= 'whee';
     $msg  ||= 'ack';
+    my $q = $^O eq 'MSWin32' ? '"' : "'";
 
     return (
         qq{echo "$text" >> $fn},
-        qq{git add $fn && git commit -m '$msg'},
+        qq{git add $fn && git commit -m $q$msg$q},
     );
 }
 


### PR DESCRIPTION
Windows shell need double quotes for strings containing spaces, but on linux in zsh, a double-quoted string containing an exclamation mark will go into some kind of interactive mode; so the tests need to select the right kind of quote at runtime.
