### PR TITLE
should not open filehandles against character-containing strings without...

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist-Zilla-PluginBundle-Git-CheckFor
 
 {{$NEXT}}
+        * fix issue with parsing utf8-encoded files
 
 0.006     2012-11-14 22:14:15 PST8PDT
 	* Add plugin to check for common merge mishaps [Mike Doherty]

--- a/lib/Dist/Zilla/Plugin/Git/CheckFor/MergeConflicts.pm
+++ b/lib/Dist/Zilla/Plugin/Git/CheckFor/MergeConflicts.pm
@@ -48,14 +48,16 @@ sub before_release {
     FILE:
     foreach my $file ( $self->zilla->files->flatten ) {
         next FILE
+            if $file->can('encoding') and $file->encoding eq 'bytes';
+
+        next FILE
             if $self->has_ignore
             and any { $file->name eq $_ } @{ $self->ignore };
 
         my $text = $file->content;
         foreach my $re ( @{ $self->merge_conflict_patterns } ) {
-            open my $from_mem_fh, '<', \$text;
-            while (<$from_mem_fh>) {
-                if ( m/($re)/ ) {
+            foreach my $line (split $/, $text)
+                if ( $line =~ m/($re)/ ) {
                     push @{ $error_files{ $file->name } }, "matched $re at line $.";
                 }
             }


### PR DESCRIPTION
... declaring the encoding

I got these errors during a release:
    Strings with code points over 0xFF may not be mapped into in-memory file handles
    Can't open 'SCALAR(0x105d2e518)' for reading: 'Invalid argument' at /Users/ether/.perlbrew/libs/19.3@std/lib/perl5/Dist/Zilla/Plugin/Git/CheckFor/MergeConflicts.pm line 68

...because my files contained unicode characters that were beyond the latin1
range (yay Russian canaries).

This change splits the file into lines using split, rather than opening a
filehandle to its reference.
