### PR TITLE
fix extra spaces seen around branch name

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/CheckFor/CorrectBranch.pm
+++ b/lib/Dist/Zilla/Plugin/Git/CheckFor/CorrectBranch.pm
@@ -42,7 +42,7 @@ sub before_release {
     $self->log_fatal($fatal_msg) if $fatal_msg;
 
     # if we're here, we're good
-    $self->log("Current branch ($cbranch) and release branch match (", join(', ', @rbranch), ")");
+    $self->log("Current branch ($cbranch) and release branch match (" . join(', ', @rbranch) .')');
     return;
 }
 


### PR DESCRIPTION
e.g. "Current branch (master) and release branch match ( master )"
