### PR TITLE
Fix blead failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,17 @@ addons:
       - aspell-en
 language: perl
 perl:
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.20"
+  - "5.22"
   - "5.24"
   - "5.26"
+  - dev     # latest point release
+  - blead   # latest git commit
 env:
   global:
     - COVERAGE=1

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist-Zilla-PluginBundle-Git-CheckFor
 
 {{$NEXT}}
+        * fix issue #26: . is no longer in @INC
 
 0.014     2016-10-10 10:27:02 CDT-0500
 	* Drop dependency on List::MoreUtils (thanks, @karenetheridge!)

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Dist-Zilla-PluginBundle-Git-CheckFor
 
 {{$NEXT}}
         * fix issue #26: . is no longer in @INC
+        * remove dependency on MooseX::AttributeShortcuts, to work around
+          installation issues on blead
 
 0.014     2016-10-10 10:27:02 CDT-0500
 	* Drop dependency on List::MoreUtils (thanks, @karenetheridge!)

--- a/lib/Dist/Zilla/Plugin/Git/CheckFor/Fixups.pm
+++ b/lib/Dist/Zilla/Plugin/Git/CheckFor/Fixups.pm
@@ -4,7 +4,6 @@ package Dist::Zilla::Plugin::Git::CheckFor::Fixups;
 
 use Moose;
 use namespace::autoclean;
-use MooseX::AttributeShortcuts;
 
 use autodie 'system';
 use IPC::System::Simple ();
@@ -24,7 +23,9 @@ with
     ;
 
 has _next_version_plugin => (
-    is      => 'lazy',
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_build__next_version_plugin',
     isa     => 'Dist::Zilla::Plugin::Git::NextVersion',
     handles => [ qw{ version_regexp first_version } ],
 );

--- a/lib/Dist/Zilla/Role/Git/Repo/More.pm
+++ b/lib/Dist/Zilla/Role/Git/Repo/More.pm
@@ -4,13 +4,12 @@ package Dist::Zilla::Role::Git::Repo::More;
 
 use Moose::Role;
 use namespace::autoclean;
-use MooseX::AttributeShortcuts;
 
 with
     'Dist::Zilla::Role::Git::Repo',
     ;
 
-has _repo => (is => 'lazy', isa => 'Git::Wrapper');
+has _repo => (is => 'ro', lazy => 1, builder => '_build__repo', isa => 'Git::Wrapper');
 sub _build__repo {
   require Git::Wrapper;
   Git::Wrapper->new(shift->repo_root)
@@ -25,7 +24,9 @@ sub _build__repo {
 has _previous_versions => (
 
     traits  => ['Array'],
-    is      => 'lazy',
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_build__previous_versions',
     isa     => 'ArrayRef[Str]',
     handles => {
 

--- a/t/plugin/correct_branch.t
+++ b/t/plugin/correct_branch.t
@@ -6,7 +6,8 @@ use Test::Fatal;
 use Test::Moose::More 0.004;
 use Path::Tiny;
 
-require 't/funcs.pm' unless eval { require funcs };
+use lib 't';
+require funcs;
 
 use Dist::Zilla::Plugin::Git::CheckFor::CorrectBranch;
 

--- a/t/plugin/fixups.t
+++ b/t/plugin/fixups.t
@@ -10,7 +10,8 @@ use Test::More;
 use Test::Fatal;
 use Test::Moose::More 0.004;
 
-require 't/funcs.pm' unless eval { require funcs };
+use lib 't';
+require funcs;
 
 use Dist::Zilla::Plugin::Git::CheckFor::Fixups;
 


### PR DESCRIPTION
This resolves all outstanding failures against the latest dev point release, including issue #26.

MooseX::AttributeShortcuts is great in a darkpan, but it adds many additional dependencies to a cpan release, and when any of these have installation issues (such as right now), everything downstream is rendered unusable.